### PR TITLE
[FEAT] 기초 인터페이스 정의 및 클래스 구현

### DIFF
--- a/app/src/main/java/com/imeanttobe/tageditor/di/MusicModule.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/di/MusicModule.kt
@@ -1,0 +1,11 @@
+package com.imeanttobe.tageditor.di
+
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+class MusicModule {
+
+}

--- a/app/src/main/java/com/imeanttobe/tageditor/editor/BaseMusicTagEditor.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/editor/BaseMusicTagEditor.kt
@@ -1,0 +1,40 @@
+package com.imeanttobe.tageditor.editor
+
+import android.content.Context
+import android.net.Uri
+import com.imeanttobe.tageditor.model.MusicMetadata
+import java.io.FileNotFoundException
+
+abstract class BaseMusicTagEditor : MusicTagEditor {
+    /**
+     * SAF 환경에서의 유효성 검사
+     * 해당 Uri를 읽고 쓸 수 있는지(rw) 확인합니다.
+     */
+    protected fun validateUri(context: Context, uri: Uri) {
+        try {
+            // "r" = 읽기 전용, "w" = 쓰기 전용, "rw" = 읽기/쓰기
+            // "rw" 모드로 열 수 있다면 파일이 존재하고 권한도 있다는 뜻입니다.
+            context.contentResolver.openFileDescriptor(uri, "rw")?.use {
+                // 블록 내에서 아무것도 안 해도, 정상적으로 열렸다면 닫히면서 통과됨
+            } ?: throw FileNotFoundException("Cannot open file descriptor for $uri")
+        } catch (e: Exception) {
+            // 권한이 없거나 파일이 없으면 예외 발생
+            throw SecurityException("Cannot access uri: $uri. Check permissions or file existence.", e)
+        }
+    }
+
+    // 실제 구현은 자식 클래스에게 위임 (매개변수도 Context, Uri로 통일)
+    abstract suspend fun parseInternal(context: Context, uri: Uri): MusicMetadata
+    abstract suspend fun saveInternal(context: Context, uri: Uri, metadata: MusicMetadata)
+
+    // 인터페이스 구현 (템플릿 메서드 패턴)
+    override suspend fun read(context: Context, uri: Uri): Result<MusicMetadata> = runCatching {
+        validateUri(context, uri) // File 대신 Uri 검증
+        parseInternal(context, uri) // 자식 클래스 호출 시에도 context, uri 전달
+    }
+
+    override suspend fun write(context: Context, uri: Uri, metadata: MusicMetadata): Result<Unit> = runCatching {
+        validateUri(context, uri)
+        saveInternal(context, uri, metadata)
+    }
+}

--- a/app/src/main/java/com/imeanttobe/tageditor/editor/BaseMusicTagEditor.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/editor/BaseMusicTagEditor.kt
@@ -17,8 +17,8 @@ abstract class BaseMusicTagEditor : MusicTagEditor {
             context.contentResolver.openFileDescriptor(uri, "rw")?.use {
                 // 블록 내에서 아무것도 안 해도, 정상적으로 열렸다면 닫히면서 통과됨
             } ?: throw FileNotFoundException("Cannot open file descriptor for $uri")
-        } catch (e: Exception) {
-            // 권한이 없거나 파일이 없으면 예외 발생
+        } catch (e: SecurityException) {
+            // 권한이 없으면 예외 발생
             throw SecurityException("Cannot access uri: $uri. Check permissions or file existence.", e)
         }
     }

--- a/app/src/main/java/com/imeanttobe/tageditor/editor/MusicTagEditor.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/editor/MusicTagEditor.kt
@@ -1,0 +1,12 @@
+package com.imeanttobe.tageditor.editor
+
+import android.content.Context
+import android.net.Uri
+import com.imeanttobe.tageditor.model.MusicMetadata
+
+interface MusicTagEditor {
+    val supportedExtensions: Set<String>
+
+    suspend fun read(context: Context, uri: Uri): Result<MusicMetadata>
+    suspend fun write(context: Context, uri: Uri, metadata: MusicMetadata): Result<Unit>
+}

--- a/app/src/main/java/com/imeanttobe/tageditor/model/MusicFile.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/model/MusicFile.kt
@@ -1,0 +1,12 @@
+package com.imeanttobe.tageditor.model
+
+import android.net.Uri
+
+data class MusicFile (
+    val uri: Uri,
+    val fileName: String,
+    val fileExtension: String,
+    val mimeType: String,
+    val size: Long,
+    val metadata: MusicMetadata
+)

--- a/app/src/main/java/com/imeanttobe/tageditor/model/MusicMetadata.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/model/MusicMetadata.kt
@@ -1,0 +1,54 @@
+package com.imeanttobe.tageditor.model
+
+data class MusicMetadata(
+    val title: String = "",
+    val artist: String = "",
+    val album: String = "",
+    val albumArtist: String = "",
+    val year: String = "",
+    val genre: String = "",
+    val composer: String = "",
+    val trackNumber: String = "",
+    val discNumber: String = "",
+    val artwork: ByteArray? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MusicMetadata
+
+        if (title != other.title) return false
+        if (artist != other.artist) return false
+        if (album != other.album) return false
+        if (albumArtist != other.albumArtist) return false
+        if (year != other.year) return false
+        if (genre != other.genre) return false
+        if (composer != other.composer) return false
+        if (trackNumber != other.trackNumber) return false
+        if (discNumber != other.discNumber) return false
+        if (artwork != null) {
+            if (other.artwork == null) return false
+            if (!artwork.contentEquals(other.artwork)) return false
+        } else if (other.artwork != null) {
+            return false
+        }
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = title.hashCode()
+        result = 31 * result + artist.hashCode()
+        result = 31 * result + album.hashCode()
+        result = 31 * result + albumArtist.hashCode()
+        result = 31 * result + year.hashCode()
+        result = 31 * result + genre.hashCode()
+        result = 31 * result + composer.hashCode()
+        result = 31 * result + trackNumber.hashCode()
+        result = 31 * result + discNumber.hashCode()
+        result = 31 * result + (artwork?.contentHashCode() ?: 0)
+        return result
+    }
+
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #2 

# 📝 작업 내용
기초가 될 음악 메타데이터와 파일을 묘사하는 데이터 클래스, 그리고 추후 구현될 태그 수정 유틸리티의 인터페이스와 추상 클래스를 정의 및 구현했어요.

## 세부 내용
- [x] 메타데이터 인터페이스 `interface MusicMetadata` 정의
- [x] 음악 파일 클래스 `data class MusicFile` 구현
- [x] 파일 처리를 위한 `interface MusicTagEditor` 정의
- [x] 인터페이스 `MusicTagEditor`를 일부 구현하고 있는 추상 클래스 `BaseMusicTagEditor` 정의
- [x] Hilt DI를 위한 모듈 파일 미리 생성 

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음