### PR TITLE
[FEAT] 저수준 파일 입출력 유틸리티 구현

### DIFF
--- a/app/src/main/java/com/imeanttobe/tageditor/editor/impl/Mp3TagEditor.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/editor/impl/Mp3TagEditor.kt
@@ -10,7 +10,8 @@ class Mp3TagEditor(override val supportedExtensions: Set<String> = setOf("mp3"))
         context: Context,
         uri: Uri
     ): MusicMetadata {
-
+        // TODO: 구현
+        return MusicMetadata()
     }
 
     override suspend fun saveInternal(
@@ -18,6 +19,6 @@ class Mp3TagEditor(override val supportedExtensions: Set<String> = setOf("mp3"))
         uri: Uri,
         metadata: MusicMetadata
     ) {
-
+        // TODO: 구현
     }
 }

--- a/app/src/main/java/com/imeanttobe/tageditor/editor/impl/Mp3TagEditor.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/editor/impl/Mp3TagEditor.kt
@@ -1,0 +1,23 @@
+package com.imeanttobe.tageditor.editor.impl
+
+import android.content.Context
+import android.net.Uri
+import com.imeanttobe.tageditor.editor.BaseMusicTagEditor
+import com.imeanttobe.tageditor.model.MusicMetadata
+
+class Mp3TagEditor(override val supportedExtensions: Set<String> = setOf("mp3")) : BaseMusicTagEditor() {
+    override suspend fun parseInternal(
+        context: Context,
+        uri: Uri
+    ): MusicMetadata {
+
+    }
+
+    override suspend fun saveInternal(
+        context: Context,
+        uri: Uri,
+        metadata: MusicMetadata
+    ) {
+
+    }
+}

--- a/app/src/main/java/com/imeanttobe/tageditor/util/FileUtil.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/util/FileUtil.kt
@@ -3,6 +3,7 @@ package com.imeanttobe.tageditor.util
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
+import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -31,11 +32,7 @@ object FileUtil {
             }
         }
         if (result == null) {
-            result = uri.path
-            val cut = result?.lastIndexOf('/')
-            if (cut != null && cut != -1) {
-                result = result.substring(cut + 1)
-            }
+            result = uri.path?.substringAfterLast('/')
         }
         return result ?: "unknown_file"
     }
@@ -61,6 +58,7 @@ object FileUtil {
      * [4] Uri -> 임시 파일(File) 복사
      * 태그 라이브러리가 'File' 객체를 요구할 때 사용합니다.
      * 앱의 캐시 디렉토리에 원본과 동일한 확장자를 가진 임시 파일을 생성하고 내용을 복사합니다.
+     * 단, 파일 삭제는 이 함수를 실행하는 측에서 진행하거나, [6]번 함수로 해야 합니다.
      */
     @Throws(IOException::class)
     suspend fun copyUriToTempFile(context: Context, uri: Uri): File = withContext(Dispatchers.IO) {
@@ -74,7 +72,6 @@ object FileUtil {
 
         // 캐시 디렉토리에 빈 파일 생성
         val tempFile = File.createTempFile("tag_editor_", suffix, tempDir)
-        tempFile.deleteOnExit() // 앱 종료 시 삭제 예약
 
         // Stream을 열어 데이터 복사
         context.contentResolver.openInputStream(uri)?.use { inputStream ->
@@ -93,7 +90,7 @@ object FileUtil {
     @Throws(IOException::class)
     suspend fun copyTempFileToUri(context: Context, tempFile: File, uri: Uri) = withContext(Dispatchers.IO) {
         // "wt" 모드: Write + Truncate (기존 내용을 지우고 처음부터 씀)
-        context.contentResolver.openOutputStream(uri, "wt")?.use { outputStream ->
+        context.contentResolver.openOutputStream(uri, "w")?.use { outputStream ->
             tempFile.inputStream().use { inputStream ->
                 inputStream.copyTo(outputStream)
             }
@@ -116,9 +113,10 @@ object FileUtil {
                     file.delete()
                 }
             }
+        } catch (e: SecurityException) {
+            Log.e("FileUtil", "Security exception while clearing temp files.", e)
         } catch (e: Exception) {
-            // 파일 삭제 실패는 치명적인 오류가 아니므로 로그만 남기고 앱은 계속 실행
-            e.printStackTrace()
+            Log.e("FileUtil", "Error clearing old temp files.", e)
         }
     }
 }

--- a/app/src/main/java/com/imeanttobe/tageditor/util/FileUtil.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/util/FileUtil.kt
@@ -107,4 +107,26 @@ object FileUtil {
             }
         } ?: throw IOException("Cannot open file descriptor for writing: $uri")
     }
+
+    /**
+     * [6] 임시 파일 제거
+     * 혹시 앱이 비정상적으로 종료되어 임시 파일이 남았을 경우를 대비,
+     * 모든 임시 파일과 캐시 디렉토리 등을 삭제하는 함수입니다.
+     * 성능 향상을 위해 입출력 디스패처에서 비동기적으로 실행합니다.
+     */
+    suspend fun clearOldTempFiles(context: Context) = withContext(Dispatchers.IO) {
+        try {
+            val tempDir = File(context.cacheDir, TEMP_DIR_NAME)
+
+            // 폴더가 존재하고 디렉토리가 맞다면 내부 파일 삭제
+            if (tempDir.exists() && tempDir.isDirectory) {
+                tempDir.listFiles()?.forEach { file ->
+                    file.delete()
+                }
+            }
+        } catch (e: Exception) {
+            // 파일 삭제 실패는 치명적인 오류가 아니므로 로그만 남기고 앱은 계속 실행
+            e.printStackTrace()
+        }
+    }
 }

--- a/app/src/main/java/com/imeanttobe/tageditor/util/FileUtil.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/util/FileUtil.kt
@@ -63,7 +63,7 @@ object FileUtil {
      * 앱의 캐시 디렉토리에 원본과 동일한 확장자를 가진 임시 파일을 생성하고 내용을 복사합니다.
      */
     @Throws(IOException::class)
-    fun copyUriToTempFile(context: Context, uri: Uri): File {
+    suspend fun copyUriToTempFile(context: Context, uri: Uri): File = withContext(Dispatchers.IO) {
         // 임시 폴더 생성
         val tempDir = File(context.cacheDir, TEMP_DIR_NAME)
         if (!tempDir.exists()) tempDir.mkdirs()
@@ -83,7 +83,7 @@ object FileUtil {
             }
         } ?: throw IOException("Cannot open input stream for uri: $uri")
 
-        return tempFile
+        tempFile
     }
 
     /**
@@ -91,21 +91,13 @@ object FileUtil {
      * 태그 라이브러리가 수정한 임시 파일을 다시 원본 위치(SAF Uri)에 저장합니다.
      */
     @Throws(IOException::class)
-    fun copyTempFileToUri(context: Context, tempFile: File, uri: Uri) {
-        context.contentResolver.openFileDescriptor(uri, "w")?.use { pfd ->
-            FileOutputStream(pfd.fileDescriptor).use { outputStream ->
-                tempFile.inputStream().use { inputStream ->
-                    inputStream.copyTo(outputStream)
-                    // 파일 크기가 줄어들었을 경우를 대비해 truncate 처리 (선택 사항이나 권장)
-                    try {
-                        val channel = outputStream.channel
-                        channel.truncate(channel.position())
-                    } catch (e: Exception) {
-                        // 일부 스트림에서 지원하지 않을 수 있음
-                    }
-                }
+    suspend fun copyTempFileToUri(context: Context, tempFile: File, uri: Uri) = withContext(Dispatchers.IO) {
+        // "wt" 모드: Write + Truncate (기존 내용을 지우고 처음부터 씀)
+        context.contentResolver.openOutputStream(uri, "wt")?.use { outputStream ->
+            tempFile.inputStream().use { inputStream ->
+                inputStream.copyTo(outputStream)
             }
-        } ?: throw IOException("Cannot open file descriptor for writing: $uri")
+        } ?: throw IOException("Cannot open output stream for uri: $uri")
     }
 
     /**

--- a/app/src/main/java/com/imeanttobe/tageditor/util/FileUtil.kt
+++ b/app/src/main/java/com/imeanttobe/tageditor/util/FileUtil.kt
@@ -1,0 +1,110 @@
+package com.imeanttobe.tageditor.util
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+
+object FileUtil {
+    // 임시 폴더명 상수
+    private const val TEMP_DIR_NAME = "saf_temp"
+
+    /**
+     * [1] 파일 이름 가져오기
+     * SAF Uri에서 표시되는 파일 이름(Display Name)을 추출합니다.
+     */
+    fun getFileName(context: Context, uri: Uri): String {
+        var result: String? = null
+        if (uri.scheme == "content") {
+            val cursor = context.contentResolver.query(uri, null, null, null, null)
+            cursor?.use {
+                if (it.moveToFirst()) {
+                    val index = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                    if (index != -1) {
+                        result = it.getString(index)
+                    }
+                }
+            }
+        }
+        if (result == null) {
+            result = uri.path
+            val cut = result?.lastIndexOf('/')
+            if (cut != null && cut != -1) {
+                result = result.substring(cut + 1)
+            }
+        }
+        return result ?: "unknown_file"
+    }
+
+    /**
+     * [2] 파일 확장자 가져오기
+     * 파일 이름에서 확장자를 추출합니다. (소문자 변환)
+     */
+    fun getFileExtension(context: Context, uri: Uri): String {
+        val fileName = getFileName(context, uri)
+        return fileName.substringAfterLast('.', "").lowercase()
+    }
+
+    /**
+     * [3] MIME 타입 가져오기
+     * 예: "audio/mpeg"
+     */
+    fun getMimeType(context: Context, uri: Uri): String {
+        return context.contentResolver.getType(uri) ?: "application/octet-stream"
+    }
+
+    /**
+     * [4] Uri -> 임시 파일(File) 복사
+     * 태그 라이브러리가 'File' 객체를 요구할 때 사용합니다.
+     * 앱의 캐시 디렉토리에 원본과 동일한 확장자를 가진 임시 파일을 생성하고 내용을 복사합니다.
+     */
+    @Throws(IOException::class)
+    fun copyUriToTempFile(context: Context, uri: Uri): File {
+        // 임시 폴더 생성
+        val tempDir = File(context.cacheDir, TEMP_DIR_NAME)
+        if (!tempDir.exists()) tempDir.mkdirs()
+
+        val extension = getFileExtension(context, uri)
+        // 확장자가 없으면 tmp, 있으면 해당 확장자 사용 (라이브러리 인식용)
+        val suffix = if (extension.isNotEmpty()) ".$extension" else ".tmp"
+
+        // 캐시 디렉토리에 빈 파일 생성
+        val tempFile = File.createTempFile("tag_editor_", suffix, tempDir)
+        tempFile.deleteOnExit() // 앱 종료 시 삭제 예약
+
+        // Stream을 열어 데이터 복사
+        context.contentResolver.openInputStream(uri)?.use { inputStream ->
+            FileOutputStream(tempFile).use { outputStream ->
+                inputStream.copyTo(outputStream)
+            }
+        } ?: throw IOException("Cannot open input stream for uri: $uri")
+
+        return tempFile
+    }
+
+    /**
+     * [5] 임시 파일(File) -> 원본 Uri 덮어쓰기
+     * 태그 라이브러리가 수정한 임시 파일을 다시 원본 위치(SAF Uri)에 저장합니다.
+     */
+    @Throws(IOException::class)
+    fun copyTempFileToUri(context: Context, tempFile: File, uri: Uri) {
+        context.contentResolver.openFileDescriptor(uri, "w")?.use { pfd ->
+            FileOutputStream(pfd.fileDescriptor).use { outputStream ->
+                tempFile.inputStream().use { inputStream ->
+                    inputStream.copyTo(outputStream)
+                    // 파일 크기가 줄어들었을 경우를 대비해 truncate 처리 (선택 사항이나 권장)
+                    try {
+                        val channel = outputStream.channel
+                        channel.truncate(channel.position())
+                    } catch (e: Exception) {
+                        // 일부 스트림에서 지원하지 않을 수 있음
+                    }
+                }
+            }
+        } ?: throw IOException("Cannot open file descriptor for writing: $uri")
+    }
+}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #4 

# 📝 작업 내용
각각의 태그 편집기가 파일을 열고 쓰는 데 필요한 저수준 파일 입출력 유틸리티를 구현했어요. 또한, 무거울 수도 있는 입출력 함수는 `Dispatchers.IO`에서 비동기적으로 실행되도록 했어요.

## 세부 내용
- [x] 실제 파일을 앱의 임시 디렉토리로 복제하는 함수 추가
- [x] 앱의 임시 디렉토리 내의 파일을 실제 파일로 덮어쓰는 함수 추가
- [x] 앱의 비정상 종료를 대비하여 앱의 임시 디렉토리 내 모든 파일을 지우는 함수 추가
- [x] 모든 IO 작업이 `Dispatchers.IO`에서 실행되도록 구현 

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음